### PR TITLE
Set the suite_name as the classname attribute

### DIFF
--- a/lib/jasmine/formatters/junit_xml.rb
+++ b/lib/jasmine/formatters/junit_xml.rb
@@ -17,6 +17,7 @@ module Jasmine
 
         results.each do |result|
           testcase = Nokogiri::XML::Node.new 'testcase', doc
+          testcase['classname'] = result.suite_name
           testcase['name'] = result.description
 
           if result.failed?


### PR DESCRIPTION
As per your comment I tested both setting the classname attribute as the suite_name and setting the name attribute to the full_name. Setting the name attribute makes it so the list has more context, but it's still a flat list. Setting the classname attribute allows you to have a little control over the nesting. Junit seems to ignore spaces and sets the nesting based on periods. So if you do something like

```javascript
describe('Class', function() {
    describe('.method_one', function() {
        it('does this');
        it('does that');
    });
    describe('.method_two', function() {
        it('does this');
        it('does that');
    });
});
```

The xml you get is
```xml
<testsuites>                                                                                                                                         
  <testsuite name="Jasmine Suite" tests="4" failures="0" errors="0">                                                                               
    <testcase classname="Class .method_one" name="does this"/>
    <testcase classname="Class .method_one" name="does that"/>
    <testcase classname="Class .method_two" name="does this"/>
    <testcase classname="Class .method_two" name="does that"/>
  </testsuite>                                                                                                                                       
</testsuites>
```

And the display gives
```
Class
    method_one
        does this
        does that
    method_two
        does this
        does that
```

This seems to be the best choice given the options.