### PR TITLE
Support for skipped specs in JUnit output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,3 @@ gem 'jasmine', :git => 'https://github.com/pivotal/jasmine-gem.git'
 # gem 'jasmine', :path => '../jasmine-gem'
 
 gem 'rack', '< 2.0.0'
-

--- a/lib/jasmine/formatters/junit_xml.rb
+++ b/lib/jasmine/formatters/junit_xml.rb
@@ -8,6 +8,7 @@ module Jasmine
         @doc = Nokogiri::XML '<testsuites><testsuite name="Jasmine Suite"></testsuite></testsuites>', nil, 'UTF-8'
         @spec_count = 0
         @failure_count = 0
+        @pending_count = 0
       end
 
       def format(results)
@@ -29,6 +30,10 @@ module Jasmine
               failure.content = failed_exp.stack
               failure.parent = testcase
             end
+          elsif result.pending?
+            @pending_count += 1
+            skipped = Nokogiri::XML::Node.new('skipped', doc)
+            skipped.parent = testcase
           end
 
           testcase.parent = testsuite

--- a/spec/lib/jasmine/formatters/junit_xml_spec.rb
+++ b/spec/lib/jasmine/formatters/junit_xml_spec.rb
@@ -48,6 +48,27 @@ describe Jasmine::Formatters::JunitXml do
       end
     end
 
+    describe 'when there are pending specs' do
+      it "shows the spec counts" do
+        results = [pending_result('fullName' => 'Pending test', 'description' => 'test')]
+        subject = Jasmine::Formatters::JunitXml.new
+
+        subject.format(results)
+        subject.done({})
+        xml = Nokogiri::XML(file_stub.content)
+
+        testsuite = xml.xpath('/testsuites/testsuite').first
+        expect(testsuite['tests']).to eq '1'
+        expect(testsuite['failures']).to eq '0'
+        expect(testsuite['name']).to eq 'Jasmine Suite'
+
+        expect(xml.xpath('//testcase').size).to eq 1
+        expect(xml.xpath('//testcase').first['classname']).to eq 'Pending'
+        expect(xml.xpath('//testcase').first['name']).to eq 'test'
+        expect(xml.xpath('//testcase/skipped').first).to_not eq(nil)
+      end
+    end
+
     describe 'when there are failures' do
       it 'shows the spec counts' do
         results1 = [passing_result]
@@ -189,5 +210,9 @@ YAML
 
   def passing_result(options = {})
     Jasmine::Result.new(passing_raw_result.merge(options))
+  end
+
+  def pending_result(options = {})
+    Jasmine::Result.new(pending_raw_result.merge(options))
   end
 end


### PR DESCRIPTION
A small change which adds a `<skipped/>` node to temporarily disabled specs (e.g with `xit`) for use with the various CI platforms' reporting