### PR TITLE
Add junit_xml_filename configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ The config file will be processed with ERB if you want to make the destination d
     ---
     junit_xml_path: <%= File.join(Dir.pwd, 'some', 'relative', 'path')
 
+### Configuring the output filename:
+
+To configure the filename of the XML file that is generated, the `junit_xml_filename` configuration option can be used, otherwise the default filename is `junit_results.xml`
+
+    ---
+    junit_xml_filename: custom_filename.junit.xml
+
 ## Contributing
 
 1. Fork it

--- a/lib/jasmine/formatters/junit_xml.rb
+++ b/lib/jasmine/formatters/junit_xml.rb
@@ -83,7 +83,7 @@ module Jasmine
         testsuite['errors'] = 0
 
         FileUtils.mkdir_p(output_dir)
-        File.open(File.join(output_dir, 'junit_results.xml'), 'w') do |file|
+        File.open(File.join(output_dir, output_filename), 'w') do |file|
           file.puts doc.to_xml(indent: 2)
         end
       end
@@ -93,6 +93,10 @@ module Jasmine
 
       def output_dir
         config['junit_xml_path'] || Dir.pwd
+      end
+
+      def output_filename
+        config['junit_xml_filename'] || 'junit_results.xml'
       end
 
       def load_config(filepath=nil)

--- a/spec/lib/jasmine/formatters/junit_xml_spec.rb
+++ b/spec/lib/jasmine/formatters/junit_xml_spec.rb
@@ -169,6 +169,64 @@ YAML
     end
   end
 
+  describe 'when the output filename has been customized' do
+    before do
+      allow(Dir).to receive(:pwd).and_return('/default_path')
+    end
+
+    it 'writes to the specified location if provided in jasmine_junitxml_formatter.yml' do
+      config_path = File.join('/default_path', 'spec', 'javascripts', 'support', 'jasmine_junitxml_formatter.yml')
+      allow(File).to receive(:exist?).with(config_path).and_return(true)
+      allow(File).to receive(:read).with(config_path).and_return <<-YAML
+---
+junit_xml_filename: "custom_filename.junit.xml"
+YAML
+      allow(File).to receive(:open).and_call_original
+      allow(File).to receive(:open).with('/default_path/custom_filename.junit.xml', 'w').and_yield(file_stub)
+
+      results = [passing_result('fullName' => 'Passing test', 'description' => 'test')]
+      subject = Jasmine::Formatters::JunitXml.new
+
+      subject.format(results)
+      subject.done({})
+      expect(file_stub.content).to_not eq ''
+    end
+
+    it 'writes to default location if junit_xml_filename is not provided in jasmine_junitxml_formatter.yml' do
+      allow(File).to receive(:open).and_call_original
+      allow(File).to receive(:open).with('/default_path/junit_results.xml', 'w').and_yield(file_stub)
+
+      results = [passing_result('fullName' => 'Passing test', 'description' => 'test')]
+      subject = Jasmine::Formatters::JunitXml.new
+
+      subject.format(results)
+      subject.done({})
+      expect(file_stub.content).to_not eq ''
+    end
+  end
+
+  describe 'when both the output directory and output filename has been customized' do
+    it 'writes to the customized location using the customized filename if provided in jasmine_junitxml_formatter.yml' do
+      allow(Dir).to receive(:pwd).and_return('/default_path')
+      config_path = File.join('/default_path', 'spec', 'javascripts', 'support', 'jasmine_junitxml_formatter.yml')
+      allow(File).to receive(:exist?).with(config_path).and_return(true)
+      allow(File).to receive(:read).with(config_path).and_return <<-YAML
+---
+junit_xml_path: "/custom_path"
+junit_xml_filename: "custom_filename.junit.xml"
+YAML
+      allow(File).to receive(:open).and_call_original
+      allow(File).to receive(:open).with('/custom_path/custom_filename.junit.xml', 'w').and_yield(file_stub)
+
+      results = [passing_result('fullName' => 'Passing test', 'description' => 'test')]
+      subject = Jasmine::Formatters::JunitXml.new
+
+      subject.format(results)
+      subject.done({})
+      expect(file_stub.content).to_not eq ''
+    end
+  end
+
   describe 'with a custom config file path' do
     before do
       allow(Dir).to receive(:pwd).and_return('/default_path')


### PR DESCRIPTION
This PR adds the ability to customize the output filename using the `junit_xml_filename` YAML atteibute . Before this filename was hardcoded as `junit_results.xml`. 